### PR TITLE
Precision casting of tensors, set_precision_advanced node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,6 +25,7 @@ NODE_CLASS_MAPPINGS = {
     "Latent Batcher": latents.latent_batch,
     "Latent Normalize Channels": latents.latent_normalize_channels,
     "Set Precision": latents.set_precision,
+    "Set Precision Advanced": latents.set_precision_advanced,
     "LatentNoiseBatch_perlin": latents.LatentNoiseBatch_perlin,
     "EmptyLatentImage64": latents.EmptyLatentImage64,
     "EmptyLatentImageCustom": latents.EmptyLatentImageCustom,

--- a/conditioning.py
+++ b/conditioning.py
@@ -5,37 +5,7 @@ import comfy.sample
 import comfy.sampler_helpers
 import node_helpers
 
-import functools
-def cast_fp64(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        # Find the first tensor argument to determine the target device
-        target_device = None
-        for arg in args:
-            if torch.is_tensor(arg):
-                target_device = arg.device
-                break
-        if target_device is None:
-            for v in kwargs.values():
-                if torch.is_tensor(v):
-                    target_device = v.device
-                    break
-        
-        # Recursive function to cast tensors in nested dictionaries
-        def cast_and_move_to_device(data):
-            if torch.is_tensor(data):
-                return data.to(torch.float64).to(target_device)
-            elif isinstance(data, dict):
-                return {k: cast_and_move_to_device(v) for k, v in data.items()}
-            return data
-
-        # Cast all tensor arguments to float64 and move them to the target device
-        new_args = [cast_and_move_to_device(arg) for arg in args]
-        new_kwargs = {k: cast_and_move_to_device(v) for k, v in kwargs.items()}
-        
-        return func(*new_args, **new_kwargs)
-    return wrapper
-
+from .noise_classes import precision_tool
 
 def initialize_or_scale(tensor, value, steps):
     if tensor is None:
@@ -227,7 +197,7 @@ class StableCascade_StageB_Conditioning64:
 
     CATEGORY = "conditioning/stable_cascade"
 
-    @cast_fp64
+    @precision_tool.cast_tensor
     def set_prior(self, conditioning, stage_c):
         c = []
         for t in conditioning:

--- a/extra_samplers.py
+++ b/extra_samplers.py
@@ -11,7 +11,7 @@ import functools
 from .noise_classes import *
 #from comfy_extras.nodes_advanced_samplers import sample_euler_cfgpp_alt
 
-@cast_fp64
+@precision_tool.cast_tensor
 @torch.no_grad()
 def sample_dpmpp_sde_advanced(
     model, x, sigmas, extra_args=None, callback=None, disable=None,
@@ -75,7 +75,7 @@ def sample_dpmpp_sde_advanced(
 
     return x
 
-@cast_fp64
+@precision_tool.cast_tensor
 @torch.no_grad()
 def sample_dpmpp_sde_cfgpp_advanced(
     model, x, sigmas, extra_args=None, callback=None, disable=None, eulers_mom=None,
@@ -168,11 +168,11 @@ def get_ancestral_step(sigma_from, sigma_to, eta=1.):
     sigma_down = (sigma_to ** 2 - sigma_up ** 2) ** 0.5
     return sigma_down, sigma_up
 
-@cast_fp64
+@precision_tool.cast_tensor
 def sample_dpmpp_dualsdemomentum_advanced(model, x, sigmas, seed=42, extra_args=None, callback=None, disable=None, eta=1., s_noise=1., noise_sampler_type="gaussian", noise_sampler=None, r=1/2, momentum=0.0, momentums=None, etas=None, s_noises=None,rs=None,scheduled_r=False):
     return sample_dpmpp_dualsde_momentum_advanced(model, x, sigmas, seed=seed, extra_args=extra_args, callback=callback, disable=disable, eta=etas, s_noise=s_noises, noise_sampler_type=noise_sampler_type, noise_sampler=noise_sampler, r=rs, momentum=momentums, scheduled_r=False)
 
-@cast_fp64
+@precision_tool.cast_tensor
 @torch.no_grad()
 def sample_dpmpp_dualsde_momentum_advanced (
     model, 
@@ -304,7 +304,7 @@ def sample_dpmpp_dualsde_momentum_advanced (
 # Many thanks to Kat + Birch-San for this wonderful sampler implementation! https://github.com/Birch-san/sdxl-play/commits/res/
 from .refined_exp_solver import sample_refined_exp_s_advanced
 
-@cast_fp64
+@precision_tool.cast_tensor
 def sample_res_solver_advanced(model, 
                                x, 
                                sigmas, etas, c2s, momentums, eulers_moms, offsets, branch_mode, branch_depth, branch_width,

--- a/latents.py
+++ b/latents.py
@@ -58,6 +58,58 @@ class set_precision:
                 torch.set_default_dtype(torch.float64)
                 x = latent_image["samples"].to(torch.float64)
         return ({"samples": x}, )
+
+class set_precision_advanced:
+    def __init__(self):
+        pass
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                    "latent_image": ("LATENT", ),      
+                    "global_precision": (["64", "32", "16"], ),
+                    "shark_precision": (["64", "32", "16"], ),
+                     },
+                }
+
+    RETURN_TYPES = ("LATENT","LATENT","LATENT","LATENT","LATENT",)
+    RETURN_NAMES = ("PASSTHROUGH","LATENT_CAST_TO_GLOBAL","LATENT_16","LATENT_32","LATENT_64",)
+    CATEGORY = "sampling/custom_sampling/"
+
+    FUNCTION = "main"
+
+    def main(self, global_precision="32", shark_precision="64", latent_image=None):
+        dtype_map = {
+            "16": torch.float16,
+            "32": torch.float32,
+            "64": torch.float64
+        }
+        precision_map = {
+            "16": 'fp16',
+            "32": 'fp32',
+            "64": 'fp64'
+        }
+
+        # Set default dtype based on global_precision
+        torch.set_default_dtype(dtype_map[global_precision])
+        # Set precision_tool cast type based on shark_precision
+        precision_tool.set_cast_type(precision_map[shark_precision])
+
+        latent_passthrough = latent_image["samples"]
+
+        # Convert latent_image["samples"] dtypes for static latent outputs
+        latent_out16 = latent_image["samples"].to(torch.float16)
+        latent_out32 = latent_image["samples"].to(torch.float32)
+        latent_out64 = latent_image["samples"].to(torch.float64)
+
+        # Convert latent for cast to global output according to global_precision
+        target_dtype = dtype_map[global_precision]
+        if latent_image["samples"].dtype != target_dtype:
+            latent_image["samples"] = latent_image["samples"].to(target_dtype)
+
+        latent_cast_to_global = latent_image["samples"]
+
+        return ({"samples": latent_passthrough}, {"samples": latent_cast_to_global}, {"samples": latent_out16}, {"samples": latent_out32}, {"samples": latent_out64})
     
 class latent_to_cuda:
     def __init__(self):

--- a/samplers.py
+++ b/samplers.py
@@ -300,13 +300,18 @@ class UltraSharkSampler:
                sigmas, guide_type, guide_weight, latent_image, latent_noise=None, guide=None, guide_weights=None): 
         
 
-            if model.model.model_config.unet_config['stable_cascade_stage'] == 'up':
+            if model.model.model_config.unet_config.get('stable_cascade_stage') == 'up':
                 x_lr = guide['samples'] if guide is not None else None
                 guide_weights = initialize_or_scale(None, guide_weight, 10000)
-                model.model.diffusion_model.set_guide_weights(guide_weights=guide_weights)
-                model.model.diffusion_model.set_guide_type(guide_type=guide_type)
-                model.model.diffusion_model.set_x_lr(x_lr=x_lr)
-            elif model.model.model_config.unet_config['stable_cascade_stage'] == 'b':
+
+                patch = patch = model.model_options.get("transformer_options", {}).get("patches_replace", {}).get("cascadeultra", {}).get("main")
+                if patch is not None:
+                    patch.update(x_lr=x_lr, guide_weights=guide_weights, guide_type=guide_type)
+                else:
+                    model.model.diffusion_model.set_guide_weights(guide_weights=guide_weights)
+                    model.model.diffusion_model.set_guide_type(guide_type=guide_type)
+                    model.model.diffusion_model.set_x_lr(x_lr=x_lr)
+            elif model.model.model_config.unet_config.get('stable_cascade_stage') == 'b':
                 c_pos, c_neg = [], []
                 for t in positive:
                     d_pos = t[1].copy()
@@ -322,6 +327,8 @@ class UltraSharkSampler:
                     c_neg.append([torch.zeros_like(t[0]), d_neg])
                 positive = c_pos
                 negative = c_neg
+            else:
+                raise ValueError("Expected model to be in stable cascade stage 'up' or 'b'")
                 
         
         


### PR DESCRIPTION
Main changes:
- Precision tool for advanced casting of tensors (default behavior is still same as cast_64)
- UltraSharkSampler compatible with CascadeUltraPatch (does not affect behavior if CascadeUltraPatch is not present)