### PR TITLE
fix issues with res4lyf config settings and sd3.5 timestep override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .tmp
 .cache
 tests/
+/*.json

--- a/res4lyf.json
+++ b/res4lyf.json
@@ -1,4 +1,0 @@
-{
-	"name": "CustomScripts",
-	"logging": false
-}

--- a/web/js/res4lyf.default.json
+++ b/web/js/res4lyf.default.json
@@ -1,0 +1,7 @@
+{
+    "name": "RES4LYF",
+    "topClownDog": true,
+    "enableDynamicWidgets": false,
+    "enableDebugLogs": false,
+    "updatedTimestepScaling": false
+}


### PR DESCRIPTION
fix issues with res4lyf config settings and default sd3.5 timestep override interfering with hyvideo (and maybe other models). Previous implementation was not changing things like timestep scaling unless browser was refreshed so this version stores all custom settings in a res4lyf.config.json file so they can reliably be seen by web interface and python backend.

And logging is much better now if the setting is enabled. Just import log from res4lyf.py