### PR TITLE
Fix: support NumPy 2.x for ComfyUI (set numpy>=2.1.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 opencv-python
 matplotlib
 pywavelets
-numpy>=1.26.4
+numpy>=2.1.0


### PR DESCRIPTION
prevent custom node from downgrading numpy in the comfyui env and then causing the below error which prevents comfyui from starting

```
Prestartup times for custom nodes:
   9.7 seconds: /ComfyUI/custom_nodes/ComfyUI-Manager

Traceback (most recent call last):
  File "/ComfyUI/main.py", line 145, in <module>
    import comfy.utils
  File "/ComfyUI/comfy/utils.py", line 44, in <module>
    from numpy.dtypes import Float64DType
ModuleNotFoundError: No module named 'numpy.dtypes'
```
