### PR TITLE
Fix noisy output when splitting sampling across multiple SharkSampler

### DIFF
--- a/beta/rk_sampler_beta.py
+++ b/beta/rk_sampler_beta.py
@@ -358,7 +358,7 @@ def sample_rk_beta(
                 sigma_up_total += sigmas[i+1]
             etas = torch.full_like(sigmas, eta / sigma_up_total)
     
-    if 'last_rng' in state_info and sampler_mode in {"resample", "unsample"} and noise_seed < 0:
+    if 'last_rng' in state_info and sampler_mode in {"resample", "unsample"}:
         last_rng         = state_info['last_rng'].clone()
         last_rng_substep = state_info['last_rng_substep'].clone()
     else:


### PR DESCRIPTION
When splitting a sampling run across multiple SharkSampler or SharkChainSampler nodes (using resample mode), the output had excess noise compared to running all steps in a single node. This only occurred when eta or eta_substep was greater than zero. This fixes it by making sure that the previous RNG state is always restored when resuming a noisy sampling process.