### PR TITLE
Fix batch size mismatch for Ultimate SD Upscale tiling

### DIFF
--- a/flux/layers.py
+++ b/flux/layers.py
@@ -146,8 +146,37 @@ class DoubleStreamBlock(nn.Module):
             operations.Linear(mlp_hidden_dim, hidden_size, bias=True, dtype=dtype, device=device),
         ) # 3072->12288, 12288->3072  (3072*4)
 
-    def forward(self, img: Tensor, txt: Tensor, vec: Tensor, pe: Tensor, mask=None, idx=0, update_cross_attn=None, style_block=None) -> Tuple[Tensor, Tensor]: # vec 1,3072  # vec 1,3072    #mask.shape 4608,4608  #img_attn.shape 1,4096,3072    txt_attn.shape 1,512,3072
+    @staticmethod
+    def _broadcast_batch_dimension(txt_tensor, img_tensor):
+        """
+        Broadcast text tensor to match image tensor batch size.
+        Handles Ultimate SD Upscale tiling where image batches > 1 but text stays at 1.
+        
+        Args:
+            txt_tensor: Text tensor with shape [batch, ...]
+            img_tensor: Image tensor with shape [batch, ...]
+        
+        Returns:
+            txt_tensor with batch dimension expanded to match img_tensor
+        """
+        txt_batch = txt_tensor.shape[0]
+        img_batch = img_tensor.shape[0]
+        
+        if txt_batch != img_batch:
+            if txt_batch == 1 and img_batch > 1:
+                # Expand text batch to match image batch
+                expand_shape = list(txt_tensor.shape)
+                expand_shape[0] = img_batch
+                return txt_tensor.expand(*expand_shape).contiguous()
+            else:
+                # Unexpected case - log warning but attempt to proceed
+                print(f"WARNING: Batch mismatch - txt_batch={txt_batch}, img_batch={img_batch}")
+                return txt_tensor
+        
+        return txt_tensor
 
+    def forward(self, img: Tensor, txt: Tensor, vec: Tensor, pe: Tensor, mask=None, idx=0, update_cross_attn=None, style_block=None) -> Tuple[Tensor, Tensor]: # vec 1,3072  # vec 1,3072    #mask.shape 4608,4608  #img_attn.shape 1,4096,3072    txt_attn.shape 1,512,3072
+        
         img_len = img.shape[-2]
         txt_len = txt.shape[-2]
 
@@ -193,11 +222,24 @@ class DoubleStreamBlock(nn.Module):
         txt_q = style_block.txt.ATTN(txt_q, "q_norm")
         txt_k = style_block.txt.ATTN(txt_k, "k_norm")
 
-        q, k, v = torch.cat((txt_q, img_q), dim=2), torch.cat((txt_k, img_k), dim=2), torch.cat((txt_v, img_v), dim=2)
-        attn = attention(q, k, v, pe=pe, mask=mask)
-        
-        txt_attn = attn[:,:txt_len]                         # 1, 768,3072
-        img_attn = attn[:,txt_len:]  
+        # Expand txt q/k/v for attention computation only if batch sizes differ
+        if txt_q.shape[0] != img_q.shape[0]:
+            txt_q_expanded = self._broadcast_batch_dimension(txt_q, img_q)
+            txt_k_expanded = self._broadcast_batch_dimension(txt_k, img_k)
+            txt_v_expanded = self._broadcast_batch_dimension(txt_v, img_v)
+            
+            q, k, v = torch.cat((txt_q_expanded, img_q), dim=2), torch.cat((txt_k_expanded, img_k), dim=2), torch.cat((txt_v_expanded, img_v), dim=2)
+            attn = attention(q, k, v, pe=pe, mask=mask)
+            
+            # Split attention - txt_attn needs to stay at original batch size
+            txt_attn = attn[:txt_q.shape[0], :txt_len]
+            img_attn = attn[:, txt_len:]
+        else:
+            q, k, v = torch.cat((txt_q, img_q), dim=2), torch.cat((txt_k, img_k), dim=2), torch.cat((txt_v, img_v), dim=2)
+            attn = attention(q, k, v, pe=pe, mask=mask)
+            
+            txt_attn = attn[:,:txt_len]
+            img_attn = attn[:,txt_len:]  
         
         img_attn = style_block.img.ATTN(img_attn, "out")
         txt_attn = style_block.txt.ATTN(txt_attn, "out")
@@ -430,6 +472,7 @@ class LastLayer(nn.Module):
     def forward_linear(self, x: Tensor, vec: Tensor) -> Tensor:
         x = self.linear(x)
         return x
+
 
 
 

--- a/flux/model.py
+++ b/flux/model.py
@@ -389,6 +389,7 @@ class ReFlux(Flux):
                 bsz       = 1 if RECON_MODE else bsz_style + 1
 
                 img, t, y, context = clone_inputs(img_orig, t_orig, y_orig, context_orig, index=cond_iter)
+                x_cond, = clone_inputs(x_orig, index=cond_iter)
                 
                 mask = None
                 if not UNCOND and 'AttnMask' in transformer_options: # and weight != 0:
@@ -448,22 +449,22 @@ class ReFlux(Flux):
                     img_y0_style = img_y0_style_orig.clone()
 
                 if mask is not None and not type(mask[0][0].item()) == bool:
-                    mask = mask.to(x.dtype)
+                    mask = mask.to(x_cond.dtype)
                 if mask_zero is not None and not type(mask_zero[0][0].item()) == bool:
-                    mask_zero = mask_zero.to(x.dtype)
+                    mask_zero = mask_zero.to(x_cond.dtype)
 
-                clip = self.time_in(timestep_embedding(t, 256).to(x.dtype)) # 1 -> 1,3072
+                clip = self.time_in(timestep_embedding(t, 256).to(x_cond.dtype)) # 1 -> 1,3072
                 if self.params.guidance_embed:
                     if guidance is None:
                         print("Guidance strength is none, not using distilled guidance.")
                     else:
-                        clip = clip + self.guidance_in(timestep_embedding(guidance, 256).to(x.dtype))
+                        clip = clip + self.guidance_in(timestep_embedding(guidance, 256).to(x_cond.dtype))
                 clip = clip + self.vector_in(y[:,:self.params.vec_in_dim])  #y.shape=1,768  y==all 0s
-                clip = clip.to(x)
+                clip = clip.to(x_cond)
         
                 img_in_dtype = self.img_in.weight.data.dtype
                 if img_in_dtype not in {torch.bfloat16, torch.float16, torch.float32, torch.float64}:
-                    img_in_dtype = x.dtype
+                    img_in_dtype = x_cond.dtype
                 
                 if ref_latents is not None:
                     h, w = 0, 0
@@ -477,7 +478,7 @@ class ReFlux(Flux):
 
                         kontext, kontext_ids = self.process_img(ref, index=1, h_offset=h_offset, w_offset=w_offset)
                         #kontext = self.img_in(kontext.to(img_in_dtype))
-                        img, img_ids = self.process_img(x)
+                        img, img_ids = self.process_img(x_cond)
                         img = torch.cat([img, kontext], dim=1)
                         img_ids = torch.cat([img_ids, kontext_ids], dim=1)
                         h = max(h, ref.shape[-2] + h_offset)
@@ -494,7 +495,7 @@ class ReFlux(Flux):
                     StyleMMDiT.datashock_ref = ref_latents[0]
                 else:
                     
-                    img = rearrange(x, "b c (h ph) (w pw) -> b (h w) (c ph pw)", ph=self.patch_size, pw=self.patch_size)
+                    img = rearrange(x_cond, "b c (h ph) (w pw) -> b (h w) (c ph pw)", ph=self.patch_size, pw=self.patch_size)
                     img = self.img_in(img.to(img_in_dtype))
                     img_ids = self._get_img_ids(img, bsz, h_len, w_len, 0, h_len, 0, w_len)
 
@@ -522,7 +523,7 @@ class ReFlux(Flux):
 
 
                 # txt_ids -> 1,414,3
-                txt_ids = torch.zeros((bsz, context.shape[-2], 3), device=img.device, dtype=x.dtype) 
+                txt_ids = torch.zeros((bsz, context.shape[-2], 3), device=img.device, dtype=x_cond.dtype) 
                 ids     = torch.cat((txt_ids, img_ids), dim=-2)   # ids -> 1,4446,3       # flipped from hidream
                 rope    = self.pe_embedder(ids)                  # rope -> 1, 4446, 1, 64, 2, 2
 
@@ -531,7 +532,7 @@ class ReFlux(Flux):
 
                 img = StyleMMDiT(img, "proj_in")
                 
-                img = img.to(x) if img is not None else None
+                img = img.to(x_cond) if img is not None else None
                 
                 total_layers = len(self.double_blocks) + len(self.single_blocks)
                 
@@ -584,7 +585,13 @@ class ReFlux(Flux):
 
                 #img = img[0:1]
                 #txt_init = txt_init[0:1]
-                img       = torch.cat([txt_init, img], dim=-2)   # 4032 + 271 -> 4303     # txt embed from double stream block   # flipped from hidream
+                
+                # Expand txt_init to match img batch size for Ultimate SD Upscale tiling
+                txt_for_concat = txt_init
+                if txt_for_concat.shape[0] != img.shape[0]:
+                    txt_for_concat = txt_for_concat.expand(img.shape[0], -1, -1).contiguous()
+                
+                img       = torch.cat([txt_for_concat, img], dim=-2)   # 4032 + 271 -> 4303     # txt embed from double stream block   # flipped from hidream
 
                 double_layers = len(self.double_blocks)
 
@@ -938,7 +945,7 @@ class ReFlux(Flux):
             elif eps.shape[0] == 1 and not UNCOND:
                 eps[0] = eps_orig[0] + y0_style_neg_synweight * (eps[0] - eps_orig[0])
             
-            #eps = eps.float()
+            eps = eps.float()
         if EO("model_eps_out"):
             self.eps_out = eps.clone()
         return eps


### PR DESCRIPTION
- Fixed RuntimeError when using Ultimate SD Upscale or Face Detailer with tiled processing
- Issue: Per-condition loop was rebuilding from full batch causing size (4) vs (2) mismatch
- Solution: Use per-condition latent slice (x_cond) instead of full batch (x)
- Added conditional batch expansion for text tensors in attention computation
- Enabled float32 conversion for output to prevent BFloat16 dtype issues

Fixes compatibility with Ultimate SD Upscale and Face Detailer nodes when using tiled CFG.