### PR TITLE
Attempting to patch to address 'return type mismatch' errors

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -358,12 +358,27 @@ def is_RF_model(model):
     modelsampling = model.inner_model.inner_model.model_sampling
     return isinstance(modelsampling, model_sampling.CONST)
 
+
 def get_res4lyf_scheduler_list():
-    scheduler_names = SCHEDULER_NAMES.copy()
+    """
+    Return a list of scheduler names suitable for node INPUT_TYPES.
+    Defensive: if comfy.samplers isn't available yet, return a list that at least contains 'beta57'.
+    """
+    try:
+        # Prefer the live comfy.samplers list if available
+        import comfy.samplers as _cs
+        try:
+            scheduler_names = _cs.SCHEDULER_NAMES.copy()
+        except Exception:
+            scheduler_names = []
+    except Exception:
+        # comfy not importable at this time
+        scheduler_names = []
+
     if "beta57" not in scheduler_names:
         scheduler_names.append("beta57")
     return scheduler_names
-
+    
 def move_to_same_device(*tensors):
     if not tensors:
         return tensors

--- a/legacy/helper.py
+++ b/legacy/helper.py
@@ -126,7 +126,19 @@ def has_nested_attr(obj, attr_path):
     return True
 
 def get_res4lyf_scheduler_list():
-    scheduler_names = SCHEDULER_NAMES.copy()
+    """
+    Return a list of scheduler names suitable for node INPUT_TYPES used by legacy modules.
+    Defensive: try to read comfy.samplers.SCHEDULER_NAMES, but always include 'beta57' as fallback.
+    """
+    try:
+        import comfy.samplers as _cs
+        try:
+            scheduler_names = _cs.SCHEDULER_NAMES.copy()
+        except Exception:
+            scheduler_names = []
+    except Exception:
+        scheduler_names = []
+
     if "beta57" not in scheduler_names:
         scheduler_names.append("beta57")
     return scheduler_names

--- a/res4lyf.py
+++ b/res4lyf.py
@@ -13,6 +13,31 @@ from aiohttp import web
 from server import PromptServer
 from tqdm import tqdm
 
+# --- IMPORT-TIME PATCH (inserted to ensure 'beta57' is visible to node definitions)
+# Ensure 'beta57' is visible to node definitions that run at import/class-definition time.
+# This is defensive: if comfy isn't importable during module import, we silently skip and rely on init().
+try:
+    import comfy.samplers as _comfy_samplers
+
+    try:
+        if hasattr(_comfy_samplers, "SCHEDULER_NAMES") and "beta57" not in _comfy_samplers.SCHEDULER_NAMES:
+            _comfy_samplers.SCHEDULER_NAMES = _comfy_samplers.SCHEDULER_NAMES + ["beta57"]
+    except Exception:
+        # don't fail import for odd edge-cases
+        pass
+
+    try:
+        # KSampler.SCHEDULERS is sometimes used by node type lists
+        if hasattr(_comfy_samplers, "KSampler") and hasattr(_comfy_samplers.KSampler, "SCHEDULERS") and "beta57" not in _comfy_samplers.KSampler.SCHEDULERS:
+            _comfy_samplers.KSampler.SCHEDULERS = _comfy_samplers.KSampler.SCHEDULERS + ["beta57"]
+    except Exception:
+        pass
+
+except Exception:
+    # comfy not importable at module import time — the init() function still adds the scheduler later
+    pass
+# --- end import-time patch ---
+
 
 CONFIG_FILE_NAME = "res4lyf.config.json"
 DEFAULT_CONFIG_FILE_NAME = "web/js/res4lyf.default.json"


### PR DESCRIPTION
based on when the schedulers get inserted into the pipeline, other nodes may be confused and return errors about mismatched lists. this patch moves the insertion point and addresses grammar errors.