### PR TITLE
Attempt to address Scheduler mismatch errors with KSampler

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,6 +24,9 @@ if new_scheduler_name not in SCHEDULER_HANDLERS:
     SCHEDULER_HANDLERS[new_scheduler_name] = bong_tangent_handler
     SCHEDULER_NAMES.append(new_scheduler_name)
 
+new_scheduler_name = "beta57"
+if new_scheduler_name not in SCHEDULER_NAMES:
+    SCHEDULER_NAMES.append(new_scheduler_name)
 
 from .res4lyf import RESplain
 
@@ -464,6 +467,7 @@ add_samplers()
 
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]
+
 
 
 


### PR DESCRIPTION
as per https://github.com/ClownsharkBatwing/RES4LYF/issues/161 this seems to address errors like

* KSampler 546:82:
  - Return type mismatch between linked nodes: scheduler, received_type(['simple', 'sgm_uniform', 'karras', 'exponential', 'ddim_uniform', 'beta', 'normal', 'linear_quadratic', 'kl_optimal', 'ays', 'ays+', 'ays_30', 'ays_30+', 'gits', 'beta_1_1', 'bong_tangent']) mismatch input_type(['simple', 'sgm_uniform', 'karras', 'exponential', 'ddim_uniform', 'beta', 'normal', 'linear_quadratic', 'kl_optimal', 'ays', 'ays+', 'ays_30', 'ays_30+', 'gits', 'beta_1_1', 'bong_tangent', 'beta57'])