### PR TITLE
Fix device mismatch in WanModel patch embedding unpatchify.

### DIFF
--- a/wan/model.py
+++ b/wan/model.py
@@ -732,11 +732,11 @@ class ReWanModel(torch.nn.Module):
             assert B2 == B, "Batch size mismatch... ya sharked it."
 
         # kncokout bias
-        b = self.patch_embedding.bias.view(1, C_out, 1, 1, 1)
+        b = self.patch_embedding.bias.view(1, C_out, 1, 1, 1).to(z.device)
         z_nobias = z - b
 
         # 2D filter -> pinv
-        w3 = self.patch_embedding.weight         # [C_out, C_in, 1, pH, pW]
+        w3 = self.patch_embedding.weight.to(z.device)  # [C_out, C_in, 1, pH, pW]
         w2 = w3.squeeze(2)                       # [C_out, C_in, pH, pW]
         out_ch, in_ch, kH, kW = w2.shape
         W_flat = w2.view(out_ch, -1)            # [C_out, in_ch*pH*pW]


### PR DESCRIPTION
### Summary         

- `patch_embedding.bias` and `patch_embedding.weight` can end up on a different device than the input tensor `z` in `ReWanModel.unpatchify`, causing runtime errors.
- Adds `.to(z.device)` on both tensors to ensure they match the input device

### Details

In `wan/model.py`, `unpatchify` accesses `self.patch_embedding.bias` and `self.patch_embedding.weight` directly. When the model weights and the intermediate latent `z` are on different devices (e.g. during offloading), this produces a `RuntimeError: Expected all tensors to be on the same device`.

The fix moves both tensors to z.device at point of use, matching the pattern already used elsewhere in the codebase.

### Test plan       

- Run a Wan generation workflow with model offloading enabled (e.g. GPU + CPU offload) and verify no device mismatch errors occur.
