### PR TITLE
Guard against empty sigma tensors in RK beta sampler

### DIFF
--- a/beta/rk_noise_sampler_beta.py
+++ b/beta/rk_noise_sampler_beta.py
@@ -806,16 +806,22 @@ class RK_NoiseSampler:
                 UNSAMPLE_FROM_ZERO = True
             #sigmas   = sigmas[1:-1]   # was cleaving off 1.0 at the end when restart looping
             sigmas   = sigmas[1:]
-            if sigmas[-1] == 0.0:
+            if sigmas.numel() > 0 and sigmas[-1] == 0.0:
                 sigmas = sigmas[:-1]
         else:
             UNSAMPLE = False
+        
+        if sigmas.numel() == 0:
+            sigmas = torch.full((1,), SIGMA_MIN, dtype=sigmas.dtype, device=sigmas.device)
         
         if hasattr(self.model, "sigmas"):
             self.model.sigmas = sigmas
             
         if sampler_mode == "standard":
             UNSAMPLE = False
+        
+        if sigmas.numel() == 0:
+            sigmas = torch.full((1,), SIGMA_MIN, dtype=sigmas.dtype, device=sigmas.device)
         
         consecutive_duplicate_mask = torch.cat((torch.tensor([True], device=sigmas.device), torch.diff(sigmas) != 0))
         sigmas = sigmas[consecutive_duplicate_mask]

--- a/beta/rk_noise_sampler_beta.py
+++ b/beta/rk_noise_sampler_beta.py
@@ -795,10 +795,10 @@ class RK_NoiseSampler:
             
         if d_noise_start_step == 0:
             sigmas = sigmas.clone() * d_noise
-        
+
         if sigmas.numel() == 0:
             sigmas = torch.full((1,), SIGMA_MIN, dtype=sigmas.dtype, device=sigmas.device)
-        
+
         UNSAMPLE_FROM_ZERO = False
         if sigmas[0] == 0.0:      #remove padding used to prevent comfy from adding noise to the latent (for unsampling, etc.)
             UNSAMPLE = True
@@ -810,7 +810,7 @@ class RK_NoiseSampler:
                 sigmas = sigmas[:-1]
         else:
             UNSAMPLE = False
-        
+
         if sigmas.numel() == 0:
             sigmas = torch.full((1,), SIGMA_MIN, dtype=sigmas.dtype, device=sigmas.device)
         
@@ -819,19 +819,19 @@ class RK_NoiseSampler:
             
         if sampler_mode == "standard":
             UNSAMPLE = False
-        
+
         if sigmas.numel() == 0:
             sigmas = torch.full((1,), SIGMA_MIN, dtype=sigmas.dtype, device=sigmas.device)
-        
+
         consecutive_duplicate_mask = torch.cat((torch.tensor([True], device=sigmas.device), torch.diff(sigmas) != 0))
         sigmas = sigmas[consecutive_duplicate_mask]
-                
+
         if sigmas.numel() > 1 and sigmas[-1] == 0:
             if sigmas[-2] < SIGMA_MIN:
                 sigmas[-2] = SIGMA_MIN
             elif (sigmas[-2] - SIGMA_MIN).abs() > 1e-4:
                 sigmas = torch.cat((sigmas[:-1], SIGMA_MIN.unsqueeze(0), sigmas[-1:]))
-                
+
         elif UNSAMPLE_FROM_ZERO and not torch.isclose(sigmas[0], SIGMA_MIN):
             sigmas = torch.cat([SIGMA_MIN.unsqueeze(0), sigmas])
         

--- a/beta/rk_noise_sampler_beta.py
+++ b/beta/rk_noise_sampler_beta.py
@@ -796,6 +796,9 @@ class RK_NoiseSampler:
         if d_noise_start_step == 0:
             sigmas = sigmas.clone() * d_noise
         
+        if sigmas.numel() == 0:
+            sigmas = torch.full((1,), SIGMA_MIN, dtype=sigmas.dtype, device=sigmas.device)
+        
         UNSAMPLE_FROM_ZERO = False
         if sigmas[0] == 0.0:      #remove padding used to prevent comfy from adding noise to the latent (for unsampling, etc.)
             UNSAMPLE = True
@@ -817,7 +820,7 @@ class RK_NoiseSampler:
         consecutive_duplicate_mask = torch.cat((torch.tensor([True], device=sigmas.device), torch.diff(sigmas) != 0))
         sigmas = sigmas[consecutive_duplicate_mask]
                 
-        if sigmas[-1] == 0:
+        if sigmas.numel() > 1 and sigmas[-1] == 0:
             if sigmas[-2] < SIGMA_MIN:
                 sigmas[-2] = SIGMA_MIN
             elif (sigmas[-2] - SIGMA_MIN).abs() > 1e-4:

--- a/beta/rk_noise_sampler_beta.py
+++ b/beta/rk_noise_sampler_beta.py
@@ -802,7 +802,7 @@ class RK_NoiseSampler:
         UNSAMPLE_FROM_ZERO = False
         if sigmas[0] == 0.0:      #remove padding used to prevent comfy from adding noise to the latent (for unsampling, etc.)
             UNSAMPLE = True
-            if sigmas[-1] == 0.0:
+            if sigmas.numel() > 0 and sigmas[-1] == 0.0:
                 UNSAMPLE_FROM_ZERO = True
             #sigmas   = sigmas[1:-1]   # was cleaving off 1.0 at the end when restart looping
             sigmas   = sigmas[1:]


### PR DESCRIPTION
## Problem
`sample_res_2s` can crash when sigma preparation produces an empty tensor. In that case `prepare_sigmas()` indexes `sigmas[-1]`/`sigmas[-2]`, which raises `IndexError`. In Comfy runs this can cascade into `torch.AcceleratorError: CUDA error: an illegal memory access was encountered` during cleanup and restart the service.

## Repro context
- stack trace points to `beta/rk_noise_sampler_beta.py` (`prepare_sigmas`, around line ~820)
- observed from workflows using `res_2s` with beta-style schedulers

## Fix
- add an early guard: if `sigmas.numel() == 0`, replace with `[SIGMA_MIN]`
- guard the tail rewrite logic so `sigmas[-1]`/`sigmas[-2]` is used only when tensor has at least 2 elements

## Validation
- `python3 -m py_compile beta/rk_noise_sampler_beta.py`
- rerun of the affected workflow proceeds past sigma preparation without the illegal-address crash

## Related
- ComfyUI tracking issue: https://github.com/Comfy-Org/ComfyUI/issues/13319
