### PR TITLE
Using raw string literal to avoid erroneous TeX escape syntax interpolation attempts by Python.

### DIFF
--- a/helper_sigma_preview_image_preproc.py
+++ b/helper_sigma_preview_image_preproc.py
@@ -847,7 +847,7 @@ class SigmasSchedulePreview(SaveImage):
         
         if torch.norm(sigma_step_size_tensor - sigma_step_size_sde_tensor) > 1e-2:
             tensors.append(sigma_step_size_sde_tensor)
-            labels.append("$Δ \hat{t}$")
+            labels.append(r"$Δ \hat{t}$")
             colors.append("gold")
             
         if sigma_hat_vals:


### PR DESCRIPTION
Solves…

```
custom_nodes/RES4LYF/helper_sigma_preview_image_preproc.py:850: SyntaxWarning: invalid escape sequence '\h'
  labels.append("$Δ \hat{t}$")
```