### PR TITLE
fix: swallow Comfy 0.19.3+ kwargs in forward_orig (wan + flux/controlnet)

### DIFF
--- a/flux/controlnet.py
+++ b/flux/controlnet.py
@@ -119,6 +119,7 @@ class ControlNetFlux(Flux):
         y: Tensor,
         guidance: Tensor = None,
         control_type: Tensor = None,
+        **kwargs,  # forward-compat: swallow Comfy 0.19.3+ kwargs
     ) -> Tensor:
         if img.ndim != 3 or txt.ndim != 3:
             raise ValueError("Input img and txt tensors must have 3 dimensions.")

--- a/wan/model.py
+++ b/wan/model.py
@@ -772,6 +772,7 @@ class ReWanModel(torch.nn.Module):
         freqs    = None,
         transformer_options = {},
         UNCOND = False,
+        **kwargs,  # forward-compat: swallow Comfy 0.19.3+ kwargs (timestep_zero_index, etc)
     ):
         r"""
         Forward pass through the diffusion model


### PR DESCRIPTION
ComfyUI 0.19.3 added a `timestep_zero_index` keyword argument to `forward_orig` calls in `comfy/ldm/flux/model.py`. The patched `forward_orig` signatures in `wan/model.py` and `flux/controlnet.py` have fixed signatures and crash with:

```
TypeError: forward_orig() got an unexpected keyword argument 'timestep_zero_index'
```

This breaks RES4LYF on any Comfy 0.19.3+ install when running Wan or Flux ControlNet workflows.

### Fix

Add `**kwargs` to absorb current and future Comfy core kwargs. Zero behavioral change — the swallowed kwargs are unused inside the patched functions.

### Diff (2 lines total)

```diff
--- a/wan/model.py
+++ b/wan/model.py
@@ -772,6 +772,7 @@ class WanModel(...):
         transformer_options = {},
         UNCOND = False,
+        **kwargs,  # forward-compat: swallow Comfy 0.19.3+ kwargs (timestep_zero_index, etc)
     ):

--- a/flux/controlnet.py
+++ b/flux/controlnet.py
@@ -120,6 +120,7 @@ def forward_orig(
         guidance: Tensor = None,
         control_type: Tensor = None,
+        **kwargs,  # forward-compat: swallow Comfy 0.19.3+ kwargs
     ) -> Tensor:
```

### Verification

- Tested on ComfyUI 0.19.3, py3.12.8, torch 2.9.1+cu128, RTX 4090 / Win11
- Before patch: TypeError on first sampling step in Wan i2v + Flux ControlNet workflows
- After patch: clean execution

### Note

Same fix pattern applies to other custom nodes that monkey-patch `forward_orig` (Comfy-WaveSpeed FBCache, comfyui-flux2fun-controlnet, ComfyUI-PuLID-Flux-Enhanced). Filing separate PRs for those repos.