### PR TITLE
Fix CWE-502 arbitrary code execution in Base64ToConditioning (closes #252)

### DIFF
--- a/conditioning.py
+++ b/conditioning.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 
 import copy
 import base64
+import io
 import pickle # used strictly for serializing conditioning in the ConditioningToBase64 and Base64ToConditioning nodes for API use. (Offloading T5 processing to another machine to avoid model shuffling.)
 
 import comfy.supported_models
@@ -484,6 +485,50 @@ class ConditioningToBase64:
 
         return {"ui": {"text": text}, "result": (text,)}
 
+class _SafeConditioningUnpickler(pickle.Unpickler):
+    # Restricts pickle.loads to classes that legitimate ComfyUI conditioning data needs.
+    # Prevents arbitrary code execution from a malicious base64 payload embedded in a shared workflow (CWE-502).
+    # See https://github.com/ClownsharkBatwing/RES4LYF/issues/252.
+    _SAFE_GLOBALS = {
+        ("torch._utils", "_rebuild_tensor_v2"),
+        ("torch._utils", "_rebuild_tensor"),
+        ("torch._utils", "_rebuild_parameter"),
+        ("torch._utils", "_rebuild_sparse_tensor"),
+        ("torch._utils", "_rebuild_sparse_coo_tensor"),
+        ("torch._utils", "_rebuild_meta_tensor_no_storage"),
+        ("torch", "Tensor"),
+        ("torch", "Size"),
+        ("torch", "device"),
+        ("torch", "dtype"),
+        ("torch", "Storage"),
+        ("torch", "FloatStorage"),
+        ("torch", "HalfStorage"),
+        ("torch", "DoubleStorage"),
+        ("torch", "BFloat16Storage"),
+        ("torch", "IntStorage"),
+        ("torch", "LongStorage"),
+        ("torch", "ShortStorage"),
+        ("torch", "CharStorage"),
+        ("torch", "ByteStorage"),
+        ("torch", "BoolStorage"),
+        ("torch", "ComplexFloatStorage"),
+        ("torch", "ComplexDoubleStorage"),
+        ("torch", "UntypedStorage"),
+        ("torch.storage", "_load_from_bytes"),
+        ("collections", "OrderedDict"),
+    }
+
+    def find_class(self, module, name):
+        if (module, name) in self._SAFE_GLOBALS:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Base64ToConditioning refused to load class {module}.{name} from the base64 payload. "
+            f"This guard blocks arbitrary code execution via crafted workflows (CWE-502). "
+            f"If this class is needed by legitimate conditioning data, please open an issue at "
+            f"https://github.com/ClownsharkBatwing/RES4LYF/issues."
+        )
+
+
 class Base64ToConditioning:
     @classmethod
     def INPUT_TYPES(cls):
@@ -499,7 +544,7 @@ class Base64ToConditioning:
 
     def main(self, data):
         conditioning_pickle = base64.b64decode(data)
-        conditioning = pickle.loads(conditioning_pickle)
+        conditioning = _SafeConditioningUnpickler(io.BytesIO(conditioning_pickle)).load()
         return (conditioning,)
 
 


### PR DESCRIPTION
## Summary

- Fixes the CWE-502 arbitrary-code-execution vulnerability in `Base64ToConditioning` reported in #252 — workflow-supplied base64 input was passed straight to `pickle.loads()`, letting any shared workflow run attacker code on the user's machine.
- Replaces `pickle.loads()` with a `_SafeConditioningUnpickler` that allow-lists only the classes needed for legitimate ComfyUI conditioning data (torch tensor + storage types, `_rebuild_tensor_v2`, `OrderedDict`). Anything else raises `UnpicklingError`.
- `ConditioningToBase64` is unchanged; existing base64 payloads continue to deserialize correctly.

## Why allow-list and not safetensors

Switching to safetensors would have been a larger API change and would break workflows that already have base64 payloads pinned in them. The allow-list approach is a drop-in replacement: the encoder and node interface are untouched, so existing T5-offload workflows keep working.

Built-in containers (`list`, `dict`, `tuple`, `str`, `int`, `float`, `bool`, `None`) come out of pickle opcodes directly and never go through `find_class`, so they don't need entries in the allow-list. The allow-list specifically covers the torch + collections classes that `pickle.dumps(conditioning)` emits.

## Test plan

Verified locally with PyTorch 2.11.0:

- [x] Legitimate float32 conditioning `[[Tensor, {pooled_output, attention_mask, guidance}]]` roundtrips bit-exact.
- [x] bfloat16 conditioning (T5's default precision) roundtrips bit-exact.
- [x] `OrderedDict` inside the conditioning dict roundtrips.
- [x] `os.system` payload via `__reduce__` is blocked with `UnpicklingError`.
- [x] `eval` payload is blocked.
- [x] `subprocess.Popen` payload is blocked.

## If a legitimate class is missing

The error message points back at this repo's issue tracker, so a missing entry surfaces as a clear bug report instead of a re-opened RCE.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)