### PR TITLE
Register beta57 via SCHEDULER_HANDLERS to fix scheduler type mismatch

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,12 +17,17 @@ import torch
 from math import *
 
 
+from functools import partial
+import comfy.samplers
 from comfy.samplers import SchedulerHandler, SCHEDULER_HANDLERS, SCHEDULER_NAMES
-new_scheduler_name = "bong_tangent"
-if new_scheduler_name not in SCHEDULER_HANDLERS:
-    bong_tangent_handler = SchedulerHandler(handler=sigmas.bong_tangent_scheduler, use_ms=True)
-    SCHEDULER_HANDLERS[new_scheduler_name] = bong_tangent_handler
-    SCHEDULER_NAMES.append(new_scheduler_name)
+
+if "bong_tangent" not in SCHEDULER_HANDLERS:
+    SCHEDULER_HANDLERS["bong_tangent"] = SchedulerHandler(handler=sigmas.bong_tangent_scheduler, use_ms=True)
+    SCHEDULER_NAMES.append("bong_tangent")
+
+if "beta57" not in SCHEDULER_HANDLERS:
+    SCHEDULER_HANDLERS["beta57"] = SchedulerHandler(handler=partial(comfy.samplers.beta_scheduler, alpha=0.5, beta=0.7), use_ms=True)
+    SCHEDULER_NAMES.append("beta57")
 
 
 from .res4lyf import RESplain

--- a/res4lyf.py
+++ b/res4lyf.py
@@ -78,15 +78,6 @@ async def log_message(request):
     except Exception as e:
         return web.Response(status=500, text=str(e))
     
-original_calculate_sigmas = comfy.samplers.calculate_sigmas
-
-def calculate_sigmas_RES4LYF(model_sampling, scheduler_name, steps):
-    if scheduler_name == "beta57":
-        sigmas = comfy.samplers.beta_scheduler(model_sampling, steps, alpha=0.5, beta=0.7)
-    else:
-        return original_calculate_sigmas(model_sampling, scheduler_name, steps)
-    return sigmas
-
 def init(check_imports=None):
     RESplain("Init")
 
@@ -102,13 +93,6 @@ def init(check_imports=None):
     if using_RES4LYF_time_snr_shift:
         comfy.model_sampling.time_snr_shift = time_snr_shift_RES4LYF
         RESplain("Using RES4LYF time SNR shift but this is deprecated and will be disabled at some completely unpredictable point in the future")
-
-    # monkey patch comfy.samplers.calculate_sigmas with custom implementation
-    comfy.samplers.calculate_sigmas = calculate_sigmas_RES4LYF
-    if "beta57" not in comfy.samplers.SCHEDULER_NAMES:
-        comfy.samplers.SCHEDULER_NAMES = comfy.samplers.SCHEDULER_NAMES + ["beta57"]
-    if "beta57" not in comfy.samplers.KSampler.SCHEDULERS:
-        comfy.samplers.KSampler.SCHEDULERS = comfy.samplers.KSampler.SCHEDULERS + ["beta57"]
 
     return True
 


### PR DESCRIPTION
Fixes #142, #153, #161, #163 - and addresses the approach in #218.

## Problem

`beta57` was registered by reassigning `SCHEDULER_NAMES` to a new list:

```python
comfy.samplers.SCHEDULER_NAMES = comfy.samplers.SCHEDULER_NAMES + ["beta57"]
```
Any node that had already done `from comfy.samplers import SCHEDULER_NAMES` holds
a reference to the original list object. Rebinding the module attribute doesn't
update those references, so those nodes never saw `beta57` - but `KSampler.SCHEDULERS`
did, causing a type mismatch that broke BasicScheduler, rgthree Context, and any
other node wiring a scheduler value across nodes.

## Fix
Register both `bong_tangent` and `beta57` through `SCHEDULER_HANDLERS` with
in-place `SCHEDULER_NAMES.append()` - the API ComfyUI provides specifically for
this purpose. Mutating the shared list and dict propagates to all existing
references regardless of import order.

The `calculate_sigmas` monkey-patch is also removed; it's unnecessary since
`calculate_sigmas()` already dispatches through `SCHEDULER_HANDLERS`.

This is the same approach `bong_tangent` already used correctly - `beta57` just
predated `SchedulerHandler` (added to ComfyUI June 2025) and was never migrated.

## Related

PR #218 identified the right fix location and the in-place append approach,
but stopped short of adding `beta57` to `SCHEDULER_HANDLERS`. Without that,
`calculate_sigmas()` would hit the "invalid scheduler" error path for `beta57`
if the monkey-patch were ever absent. This PR completes the fix by registering
`beta57` as a proper `SchedulerHandler` and removing the monkey-patch entirely.

## Tests

Tested with https://github.com/alexopus/ComfyUI-Image-Saver and https://github.com/alexopus/ComfyUI-Image-Saver/issues/100#issuecomment-3221028763 is no longer broken after applying this.
