### PR TITLE
Fix CUDA misaligned address crash with regional conditioning masks

### DIFF
--- a/sd/attention.py
+++ b/sd/attention.py
@@ -445,6 +445,11 @@ def attention_pytorch(q, k, v, heads, mask=None, attn_precision=None, skip_resha
         # add a heads dimension if there isn't already one
         if mask.ndim == 3:
             mask = mask.unsqueeze(1)
+        # Regional conditioning masks are sliced from a concatenated
+        # [cross|self] tensor, producing non-contiguous views.  The
+        # efficient-attention CUDA kernel requires aligned memory.
+        if not mask.is_contiguous():
+            mask = mask.contiguous()
 
     if SDP_BATCH_LIMIT >= b:
         out = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=mask, dropout_p=0.0, is_causal=False)


### PR DESCRIPTION
## Problem

Using ReSDPatcher + ClownRegionalConditioning_AB on SDXL at non-square resolutions (e.g. 1216x832 landscape) crashes ComfyUI with:

```txt
terminate called after throwing an instance of 'c10::AcceleratorError'
  what():  CUDA error: misaligned address
Exception raised from free_impl at CUDAMallocAsyncAllocator.cpp:206
```

The crash happens inside `attention_pytorch()` when `scaled_dot_product_attention` receives a non-contiguous attention mask.

## Root cause

`SplitAttentionMask.generate()` builds a single concatenated tensor: `[cross_attn_mask | self_attn_mask]`. Later, `openaimodel._forward()` slices it into separate cross and self masks:

```python
transformer_options['cross_mask'] = mask[:,:txt_len]
transformer_options['self_mask']  = mask[:,txt_len:]
```

These slices are non-contiguous views (stride doesn't match element size). The efficient-attention CUDA kernel inside `scaled_dot_product_attention` requires aligned memory, so passing these views causes `cudaErrorMisalignedAddress`.

## Fix

Added a contiguity guard in `attention_pytorch()` after the mask reshaping, before it reaches the CUDA kernel. The check is conditional (`is_contiguous()`) so it's a no-op when masks are already contiguous.

## Testing

Tested with SDXL (Bismuth Illustrious v7.0) + ReSDPatcher + ClownRegionalConditioning_AB at 1216x832 landscape resolution. Before the fix: consistent crash on every run. After: runs to completion.